### PR TITLE
wsi improvements & cleanups

### DIFF
--- a/blahst-helpers
+++ b/blahst-helpers
@@ -1,0 +1,59 @@
+#!/bin/zsh
+
+#---HELPER FUNCTIONS--------------------------------------------------------------------------
+#Notification code, prefers zenity, then notify-send, which should be available across the
+#most distributions, in package libnotify or libnotify-bin:
+desknote() {
+    local title="$1"
+    local message="$2"
+
+    if command -v zenity &> /dev/null; then
+        zenity --no-wrap --info --text="${title}.\n$message"
+    elif command -v notify-send &> /dev/null; then
+        notify-send "$title" "$message"
+    elif command -v kdialog &> /dev/null; then
+        kdialog --passivepopup "$message" 5
+    else
+        echo "Notification Message: $message" >&2
+        echo "Please install zenity or notify-send to use notifications." >&2
+        echo "You can install either using your package manager, e.g.:" >&2
+        echo "  sudo apt-get install zenity or sudo apt-get install libnotify-bin" >&2
+        echo "  sudo yum install zenity or sudo apt-get install libnotify" >&2
+        echo "  sudo pacman -S zenity, etc." >&2
+    fi
+}
+#Choose a prompt (role) for the LLM:
+select_role () {
+    local keys=("${(@k)BMPROMPT}")
+    local role=$(zenity --title="BlahstBot Prompt" --height=$((${#keys} * 50)) --list --text="Select an LLM Role:" --column="Role" "${keys[@]}")
+    echo $BMPROMPT[$role] > $TEMPD/chatbot_prompt
+    [[ "$role" == "Personal Doctor" ]] && BOTMODEL="$AI/medgemma-27b-text-it-UD-IQ3_XXS.gguf"
+    #we do not want to have the normally false status of the condition above become the function status:
+    return 0
+}
+
+
+# First argument: x11 || wayland
+# Second argument: mouse || ctrl-v
+# if omitted, it's guessed from $PRIMESEL
+
+# When simply clicking the middle mouse button, the user must take care of: 1. Window choice. 2. Position within window.
+# Thus, autopaste from the primary selection is more unpredictable and requires extra care of window focus and mouse pointer repositioning.
+# The automatic paste option makes more sense when using the CLIPBOARD, not primary sellection.
+autopaste() {
+    (( ! $AUTOPASTE )) && return
+    wm="$1" && shift # "x11" || "wayland"
+    if [[ -n "$1" ]]; then
+	paste_type="$1" && shift # "mouse" || "ctrl-v"
+    else
+	(( $PRIMESEL )) && paste_type=mouse || paste_type=ctrl-v
+    fi
+
+    # wayland + ydotool
+    if [[ $wm == wayland ]] && command -v ydotool &> /dev/null; then
+	# The key sym sequence may differ from the one below on a variety of systems and keyboard layouts:
+	[[ $paste_type == mouse ]] && ydotool click 0xC2 || ydotool key 37:1 55:1 55:0 37:0
+    else # xdotool fallback
+	[[ $paste_type == mouse ]] && xdotool click 2 || xdotool key ctrl+v
+    fi
+}

--- a/blahst.cfg
+++ b/blahst.cfg
@@ -2,14 +2,11 @@
 wm="$XDG_SESSION_TYPE"
 #wm="${XDG_SESSION_TYPE:-$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type --value)}"
 
-#---USER CONFIGURATION BLOCK----------------------------------------------------------------------
-#Please, adjust the variables here to suit your environment
 #---------start-section-common
-# Store temp files in memory for speed and to reduce SSD/HDD "grinding":
-TEMPD='/dev/shm'
+
 # Hardcoded temp wav file to store the speech audio and get overwritten every time (in RAM):
-ramf="$TEMPD/wfile"
-#deleteramf=0
+ramf="/dev/shm/wfile-$USER"
+# KEEP_TEMP_FILE=0
 #Set the number of processing threads for whisper.cpp inference (adjust for your case):
 NTHR=8
 #It seems that the optimum number of transcribe threads should equal half CPU processing cores:
@@ -27,7 +24,8 @@ WPORT="58080"
 #The superdirectory where AI models (Whisper, LLMS, TTS etc.) are stored:
 AI="$HOME/AI/Models"
 # Default whisper.cpp model file for local ASR inference (base.en provides excellent WER for English only)
-#WMODEL="$TEMPD/ggml-base.en.bin"
+# Store temp files in memory for speed and to reduce SSD/HDD "grinding"
+#WMODEL="/dev/shm/ggml-base.en.bin"
 WMODEL=${WHISPER_DMODEL:-"$AI/whisper/ggml-base.en.bin"}
 # Uncomment to use available whisperfile (WITH BUILT-IN MODEL) instead of standalone whisper.cpp or whisper.cpp server
 #WHISPERFILE="whisper-tiny.en.llamafile" #available from https://huggingface.co/Mozilla/whisperfile/tree/main
@@ -130,100 +128,3 @@ typeset -A modrate=(
 ["TR"]=22050
 ["UA"]=22050
 )
-
-#Set next to 1 ONLY if the program has confirmed that all dependenncies are met and you do not want to check in the future:
-blahst_deps=0
-#Can be done automatically by user input during initial run of blahst_depends(). 
-#---END USER CONFIG BLOCK------------------------------------------------------------------------
-
-#---HELPER FUNCTIONS--------------------------------------------------------------------------
-#Notification code, prefers zenity, then notify-send, which should be available across the
-#most distributions, in package libnotify or libnotify-bin:
-desknote() {
-    local title="$1"
-    local message="$2"
-
-    if command -v zenity &> /dev/null; then
-        zenity --info --text="${title}.\n$message"
-    elif command -v notify-send &> /dev/null; then
-        notify-send "$title" "$message"
-    elif command -v kdialog &> /dev/null; then
-        kdialog --passivepopup "$message" 5
-    else
-        echo "Notification Message: $message" >&2
-        echo "Please install zenity or notify-send to use notifications." >&2
-        echo "You can install either using your package manager, e.g.:" >&2
-        echo "  sudo apt-get install zenity or sudo apt-get install libnotify-bin" >&2
-        echo "  sudo yum install zenity or sudo apt-get install libnotify" >&2
-        echo "  sudo pacman -S zenity, etc." >&2
-    fi
-}
-#Choose a prompt (role) for the LLM:
-select_role () {
-    local keys=("${(@k)BMPROMPT}")
-    local role=$(zenity --title="BlahstBot Prompt" --height=$((${#keys} * 50)) --list --text="Select an LLM Role:" --column="Role" "${keys[@]}")
-    echo $BMPROMPT[$role] > $TEMPD/chatbot_prompt
-    [[ "$role" == "Personal Doctor" ]] && BOTMODEL="$AI/medgemma-27b-text-it-UD-IQ3_XXS.gguf"
-    #we do not want to have the normally false status of the condition above become the function status:
-    return 0
-}
-
-#Checks for dependencies:
-blahst_depends() {
-    #---CHECK DEPENDENCIES.-----------------------------------
-    #The install-wsi script should have taken care of this, left here for the manual install.
-    command -v curl &>/dev/null || { echo "curl is required. Please, install curl" >&2 ; exit 1 ; }
-    #The next is needed if curl requests json output from the whisper.cpp or llama.cpp server;
-    command -v jq &>/dev/null || { echo "jq is required. Please, install jq" >&2 ; exit 1 ; }
-    command -v sox &>/dev/null || { echo "sox is required. Please, install sox" >&2 ; exit 1 ; }
-    [[ -n $WHISPERFILE ]] || command -v transcribe &>/dev/null || { echo -e "Please, install whisper.cpp (see https://github.com/ggerganov/whisper.cpp)\
-    \nor download a whisperfile portable executable w model inside (see https://huggingface.co/Mozilla/whisperfile/tree/main)\
-    \nand create 'transcribe' in your PATH as a symbolic link to the chosen executable, e.g.\n \
-     'ln -s /full/path/to/whisper.cpp/whisper-cli \$HOME/.local/bin/transcribe'" >&2 ; exit 1 ; }
-    command -v llam &>/dev/null || { echo -e "For interaction with an AI, install llama.cpp (see https://github.com/ggerganov/llama.cpp)\
-    \nor download a llamafile portable executable (see https://huggingface.co/Mozilla)\
-    \nand create in your PATH a symbolic link to the llama-cli executable, e.g.\n \
-     'ln -s /full/path/to/llama.cpp/llama-cli \$HOME/.local/bin/llam'" >&2 ; exit 1 ; }
-    command -v piper &>/dev/null || { echo -e "Please, install piper text-to-speech (see https://github.com/rhasspy/piper)\
-    \nto use the AI assistant and translator features with human-like voice response." >&2 ; exit 1 ; }
-    # We will use zenity or notify-send (part of libnotify or libnotify-bin in some distros) for desktop notifications:
-    command -v zenity &>/dev/null || command -v notify-send &>/dev/null || { echo "zenity or notify-send needed for error reporting. Please, install zenity or libnotify-bin" >&2 ; exit 1 ; }
-    #Now let's check if we are in X11 or Wayland and use the right utility:
-    if [[ wm == "wayland" ]]; then
-        command -v wl-copy &>/dev/null || { echo "wl-copy is needed for the clipboard. Please, install wl-copy" >&2 ; exit 1 ; } 
-        if (( $AUTOPASTE )); then 
-           command -v ydotool &>/dev/null || { echo "To have the transcribed text pasted automatically at the cursor position, please install ydotool" >&2 ; exit 1 ; }
-        fi
-    elif [[ wm == "x11" ]]; then
-        command -v xsel &>/dev/null || { echo "We rely on xsel for the clipboard. Please, install xsel." >&2 ; exit 1 ; }
-        if (( $AUTOPASTE )); then 
-           command -v xdotool &>/dev/null || { echo "To have the transcribed text pasted automatically at the cursor position, please install xdotool" >&2 ; exit 1 ; }
-        fi
-    fi
-    for llv in $WMODEL $LLMODEL $LIGHTLMODEL $HEAVYMODEL $TTSMODEL $TRANSMODEL $CODEMODEL $BOTMODEL
-    do
-    [[ -f $llv ]] || { desknote "Model file not found: " "$llv was not found. \nPlease, adjust in USER CONFIGURATION BLOCK." ; exi1 1 ; }
-    done 
-    [[ -n $LLAMAFILE ]] && { command -v $LLAMAFILE &>/dev/null || { desknote "Not found: " "Executable $LLAMAFILE not found." ; exit 1 ; } }
-    [[ -n $WHISPERFILE ]] && { command -v $WHISPERFILE &>/dev/null || { desknote "Not found: " "Executable $WHISPERFILE not found." ; exit 1 ; } }
-    #All PASS...
-    command -v zenity &>/dev/null && {
-    if zenity --question --text="Dependencies of BlahST are met. Do you want to skip future dependency checks?"; then
-        # Update the configuration file to set blahst_deps to 1 (we are sourcing this so hardcoding the filename)
-        sed -i 's/^blahst_deps=0/blahst_deps=1/' $HOME/.local/bin/blahst.cfg
-        desknote "Skipping future dependency checks confirmed!" "To undo, manually set blahst_deps=0 in blahst.cfg."
-    fi
-    } || {
-    echo -e "\nLooks like you have all dependencies installed.\nTo disable future checks, must set blahst_deps=1 in blahst.cfg.\n"
-    read -p "Do you want me to set 'blahst_deps=1' and skip future dependency checks? (y/n) " answer
-    if [[ "$answer" == "y" || "$answer" == "Y" ]]; then
-        # Update the configuration file to set blahst_deps=1
-        sed -i 's/^blahst_deps=0/blahst_deps=1/' $HOME/.local/bin/blahst.cfg
-        echo "Skipping future dependency checks confirmed! To undo, manually set blahst_deps=0 in blahst.cfg."
-    fi
-    }
-    desknote "Dependencies installed" "\nLooks like you have all dependencies installed.\n \
-    This check will not run if you set (or have set) blahst_deps=1 in blahst.cfg.\n \
-    \nYou can run $0 --help from the Terminal to learn about its options..."
-    #---END CHECK DEPENDENCIES. This function will not be called if blahst_deps set to 1 after successful 1st run-------------
-}

--- a/blahstbot
+++ b/blahstbot
@@ -25,15 +25,12 @@ pidof -q blahstbot && exit 0
 
 #---USER CONFIGURATION BLOCK----------------------------------------------------------------
 #The main configuration for this and all other BlahST tools is now in blahst.cfg, please, edit that file as needed.
-source $HOME/.local/bin/blahst.cfg
+source $HOME/.config/blahst.cfg
+source $HOME/.local/bin/blahst-helpers
 #Local overrides:
 CHATMODE=1 #temp reuse as flag variable, untill we support llamafiles.
 AUTOPASTE=0
 #---END USER CONFIG BLOCK-------------------------------------------------------------------
- 
-#---CHECK DEPENDENCIES.-----Run blahst_depends only if needed or requested----------
-(( $blahst_deps )) || blahst_depends 
-#---END CHECK DEPENDENCIES.-----------------------------------------------------------------
 
 #Hear the complaints of components and do not continue with the sequence:
 set -e
@@ -41,35 +38,18 @@ set -o pipefail
 
 clipaste() {
     local str="$1"
-    #xsel or wl-copy:
     case "$wm" in
-        "x11")
-            if (( $PRIMESEL )); then
-              echo $str | xsel -ip
-              # Simply clicking the middle mouse button. The user has to take care of: 1. Window choice. 2. Position within window.
-              # Thus, autopaste from the primary selection is more unpredictable and requires extra care of window focus and mouse pointer repositioning. 
-              if (( $AUTOPASTE )); then xdotool click 2 ; fi
-            else
-              echo $str | xsel -ib
-              # The automatic paste option makes more sense when using the CLIPBOARD, not primary sellection.
-              if (( $AUTOPASTE )); then xdotool key ctrl+v ; fi
-            fi
-            ;;
-        "wayland")
-            if (( $PRIMESEL )); then
-              echo $str | wl-copy -p
-              # Simply clicking the middle mouse button. The user has to take care of: 1. Window choice. 2. Position within window.
-              # Thus, autopaste from the primary selection is more unpredictable and requires extra care of window focus and mouse pointer repositioning. 
-              if (( $AUTOPASTE )); then ydotool click 0xC2; fi
-            else
-              echo $str | wl-copy
-              # The key sym sequence may differ from the one below on a variety of systems and keyboard layouts:
-              if (( $AUTOPASTE )); then ydotool key 37:1 55:1 55:0 37:0 ; fi
-            fi 
-            ;;
-        *)
-            echo $str
-            ;;
+	x11)
+	    echo $str | { (( $PRIMESEL )) && xsel -ip || xsel -ib; }
+	    autopaste $wm
+	    ;;
+	wayland)
+	    echo $str | { (( $PRIMESEL )) && wl-copy -p || wl-copy; }
+	    autopaste $wm
+	    ;;
+	*)
+	    echo $str
+	    ;;
     esac
 }
 

--- a/blooper
+++ b/blooper
@@ -24,7 +24,8 @@ pidof -q blooper && exit 0
 
 #---USER CONFIGURATION BLOCK----------------------------------------------------------------
 #The main configuration for this and all other BlahST tools is now in blahst.cfg, please, edit that file as needed.
-source $HOME/.local/bin/blahst.cfg
+source $HOME/.config/blahst.cfg
+source $HOME/.local/bin/blahst-helpers
 #Local overrides:
 #none needed
 #---END USER CONFIG BLOCK-------------------------------------------------------------------

--- a/check_deps
+++ b/check_deps
@@ -1,0 +1,56 @@
+#!/bin/zsh
+
+# Checks dependencies
+blahst_depends() {
+    err=
+    verr=
+    command -v curl &>/dev/null || { echo "curl is missing" >&2 && err=1; }
+    #The next is needed if curl requests json output from the whisper.cpp or llama.cpp server
+    # command -v jq &>/dev/null || { echo "jq is missing" >&2 && err=1; }
+    command -v sox &>/dev/null || { echo "sox is missing" >&2 && err=1; }
+    [[ -n $WHISPERFILE ]] || command -v transcribe &>/dev/null || { echo -e "whisper.cpp is missing (see https://github.com/ggerganov/whisper.cpp)\
+    \n\tor download a whisperfile portable executable w model inside (see https://huggingface.co/Mozilla/whisperfile/tree/main)\
+    \n\tand create 'transcribe' in your PATH as a symbolic link to the chosen executable, e.g.\n\t\
+    'ln -s /full/path/to/whisper.cpp/whisper-cli \$HOME/.local/bin/transcribe'" >&2 ; err=1 ; }
+    command -v llam &>/dev/null || { echo -e "llama.cpp is missing for interaction with an AI (see https://github.com/ggerganov/llama.cpp)\
+    \n\tor download a llamafile portable executable (see https://huggingface.co/Mozilla)\
+    \n\tand create in your PATH a symbolic link to the llama-cli executable, e.g.\n\t\
+    'ln -s /full/path/to/llama.cpp/llama-cli \$HOME/.local/bin/llam'" >&2 ; err=1 ; }
+    command -v piper &>/dev/null || { echo -e "piper text-to-speech is missing (see https://github.com/rhasspy/piper)\
+    \n\tto use the AI assistant and translator features with human-like voice response." >&2 ; err=1 ; }
+    # We will use zenity or notify-send (part of libnotify or libnotify-bin in some distros) for desktop notifications:
+    command -v zenity notify-send &>/dev/null || { echo "Either one of zenity or notify-send (libnotify-bin) is needed for error reporting" >&2 ; err=1 ; }
+
+    #Now let's check if we are in X11 or Wayland and use the right utility:
+    wm="${XDG_SESSION_TYPE:-$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type --value)}"
+    if [[ wm == "wayland" ]]; then
+        command -v wl-copy &>/dev/null || { echo "wl-copy is missing for clipboard control" >&2 ; err=1 ; }
+        if (( $AUTOPASTE )); then
+           command -v ydotool &>/dev/null || { echo "ydotool is missing to have the transcribed text pasted automatically at the cursor position " >&2 ; err=1 ; }
+        fi
+    elif [[ wm == "x11" ]]; then
+        command -v xsel &>/dev/null || { echo "xsel is missing for clipboard control." >&2 ; err=1 ; }
+        if (( $AUTOPASTE )); then
+           command -v xdotool &>/dev/null || { echo "xdotool is missing to have the transcribed text pasted automatically at the cursor position " >&2 ; err=1 ; }
+        fi
+    fi
+
+    for llv in "$WMODEL" "$LLMODEL" "$LIGHTLMODEL" "$HEAVYMODEL" "$TTSMODEL" "$TRANSMODEL" "$CODEMODEL" "$BOTMODEL"; do
+	[[ -f $llv ]] || verr+="\nModel file \"$llv\" not found"
+    done
+
+    [[ -n $LLAMAFILE ]] && { command -v $LLAMAFILE &>/dev/null || { verr+="\nNot found: " "Executable $LLAMAFILE not found." ; } }
+    [[ -n $WHISPERFILE ]] && { command -v $WHISPERFILE &>/dev/null || { verr+="\nNot found: " "Executable $WHISPERFILE not found." ; } }
+    [[ -n $verr ]] && desknote "$verr"
+    [[ -n $err || -n $verr ]] && exit 1
+
+    exit 0
+}
+
+[[ -f blahst.cfg ]] && source blahst.cfg || source $HOME/.config/blahst.cfg
+[[ -f blahst-helpers ]] && source blahst-helpers || source $HOME/.local/bin/blahst-helpers
+
+cmd="$1" && shift
+[[ $cmd == wsi || $cmd == wsiAI || $cmd == blooper ]] && AUTOPASTE=1
+[[ $cmd == blahstbot ]] && AUTOPASTE=0
+blahst_depends

--- a/install-wsi
+++ b/install-wsi
@@ -5,15 +5,9 @@
 if [ ! -e "wsi" ]; then echo "Please, cd into the directory where the wsi script (part of BlahST) is located." ; exit 1 ; fi 
 # Define the directory for the executable scripts
 dir="$HOME/.local/bin"
-echo ""
+dir_config="$HOME/.config"
 echo ">>>>>>>>>>>> BlahST Installation <<<<<<<<<<<<<"
-echo ""
-echo "Checking for $dir..."
-# Check if the directory exists, if not, create it
-if [ ! -d "$dir" ]; then
-    mkdir -p "$dir"
-    echo "Directory $dir created."
-fi
+mkdir -vp "$dir" "$dir_config"
 
 if echo "$PATH" | grep -q ":$dir:"; then
     echo "Directory $dir is already in the PATH."
@@ -36,17 +30,12 @@ echo ""
 echo "1. ---------------------------------------------------------"
 echo "Copying the orchestrator script(s) to $HOME/.local/bin..."
 # Copy the script files
-chmod +x "wsi" "wsiml" "wsiAI" "blooper" "blahstbot"
-cp -t "$dir" "wsi" "wsiml" "wsiAI" "blooper" "blahstbot" "blahst.cfg"
+chmod +x wsi wsiml wsiAI blooper blahstbot blahst-helpers
+cp -t "$dir" wsi wsiml wsiAI blooper blahstbot
+cp -t "$dir_config" blahst.cfg
 echo "BlahST scripts copied and made executable. \$PATH updated."
 
-echo ""
-echo "2.=========================================================="
-echo -n "Checking for sox..."
-if ! command -v sox >/dev/null  2>&1; then
-    echo "sox is not installed. Please, install sox (e.g. sudo apt install sox...)"; exit  1
-fi
-echo "   OK"
+# ToDo: ask user to configure blahst.cfg then just run `check_deps`
 
 #Now let's check if we are in X11 or Wayland and use the right utility:
 wm="${XDG_SESSION_TYPE:-$(loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type --value)}"

--- a/wsi
+++ b/wsi
@@ -1,7 +1,7 @@
 #!/usr/bin/zsh
 # Operation in bash is not guaranteed.
 # Copyright (c) 2024, 2025 Quantius Benignus
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -11,8 +11,8 @@
 # SOFTWARE.
 #--------------------------------------------------------------------------
 
-# NAME: wsi 
-# PREREQUSITES: 
+# NAME: wsi
+# PREREQUSITES:
 #  - whisper.cpp installation (see https://github.com/ggerganov/whisper.cpp) or a portable whisperfile
 #  - recent versions of 'sox', 'curl', 'xsel' or 'wl-copy' and CLI tools from your system's repositories.
 #  - optional xdotool (X11) or ydotool (Wayland) for automatic paste after successful transcription
@@ -23,15 +23,12 @@ pidof -q wsi && exit 0
 
 #---USER CONFIGURATION BLOCK----------------------------------------------------------------
 #The main configuration for this and all other BlahST tools is now in blahst.cfg, please, edit that file as needed.
-source $HOME/.local/bin/blahst.cfg
+source $HOME/.config/blahst.cfg
+source $HOME/.local/bin/blahst-helpers
 #Local overrides:
 AUTOPASTE=1
 #PRIMESEL=1
 #---END USER CONFIG BLOCK-------------------------------------------------------------------
- 
-#---CHECK DEPENDENCIES.-----Run blahst_depends only if needed or requested----------
-(( $blahst_deps )) || blahst_depends 
-#---END CHECK DEPENDENCIES.-----------------------------------------------------------------
 
 # Process command line arguments first
 while [ $# -gt 0 ]; do
@@ -55,10 +52,10 @@ while [ $# -gt 0 ]; do
         -n|--netapi)
             #This uses the hostname or IP and port specified in the config block
             #Can be overwritten with a supplied command-line argument IP:PORT instead of this option
-            IPnPORT="$WHOST:$WPORT" 
+            IPnPORT="$WHOST:$WPORT"
             if [[ "$(curl -s -f -o /dev/null -w '%{http_code}' $IPnPORT)" != "200" ]]; then
-                echo "Can't connect to whisper.cpp server at provided address!" >&2  
-                desknote "No connection to Whisper.cpp server" "No whisper.cpp server at $IPnPORT."   
+                echo "Can't connect to whisper.cpp server at provided address!" >&2
+                desknote "No connection to Whisper.cpp server" "No whisper.cpp server at $IPnPORT."
                 exit 1
             fi
             shift
@@ -75,8 +72,8 @@ while [ $# -gt 0 ]; do
             #The network address and port should have already been sanitized in extension
             IPnPORT=$1
             if [[ "$(curl -s -f -o /dev/null -w '%{http_code}' $IPnPORT)" != "200" ]]; then
-                echo "Can't connect to a whisper.cpp server at provided address!" >&2   
-                desknote "No connection to Whisper.cpp server" "No whisper.cpp server at $IPnPORT."   
+                echo "Can't connect to a whisper.cpp server at provided address!" >&2
+                desknote "No connection to Whisper.cpp server" "No whisper.cpp server at $IPnPORT."
                 exit 1
             fi
             shift
@@ -84,79 +81,97 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+send_audio() {
+    #The server inference has precedence (i.e. -w will be ignored if -n is present).
+    if [ -n "$IPnPORT" ]; then
+	str=$(curl -S -s $IPnPORT/inference \
+		   -H "Content-Type: multipart/form-data" \
+		   -F file="@$ramf" \
+		   -F language="${LANGUAGE:-auto}" \
+		   -F temperature="0.0" \
+		   -F temperature_inc="0.2" \
+		   -F response_format="text")
+	# | jq -r '.text' )
+    elif [[ "$whf" == *.llamafile ]]; then
+	#echo "Using whisperfile: "
+	str="$($whf -t $NTHR -nt -f '$ramf' 2>/dev/null)"
+    else
+	str="$(transcribe -t $NTHR -nt -m $WMODEL -f '$ramf' 2>/dev/null)"
+    fi
+
+    [[ ${KEEP_TEMP_FILE:-0} != 1 ]] && rm -f "$ramf"
+
+    # Whisper detected non-speech events such as (wind blowing):
+    str="${str/\(*\)}"
+    str="${str/\[*\]}"
+    str="${str#$'\n'}"
+    str="${str#$'\n'}"
+    #Prefer the power of zsh, but lose full POSIX compliance.
+    if [ -n "$ZSH_NAME" ]; then
+	str="${str#*([[:space:]])}"
+	str="${(C)str:0:1}${str#?}"
+    elif [ -n "$BASH" ]; then
+	#Running in bash because you changed the shebang on line 1
+	str="${str##+([[:space:]])}"
+	str="${str^}"
+    else
+	echo "Unknown shell, assuming bash compliance"
+	str="${str##+([[:space:]])}"
+	str="${str^}"
+    fi
+}
+
+handle_transcription() {
+    #We have a result, now we make a few decisions:
+    #If this is somehow run in a text console:
+    if [[ -z $DISPLAY || -z $DESKTOP_SESSION || -z $XDG_CURRENT_DESKTOP ]]; then
+	#"Not running in a known graphics environment. Using standard output:
+	echo $str ; exit 0
+    else
+	case "$wm" in
+	    x11)
+		echo $str | { (( $PRIMESEL )) && xsel -ip || xsel -ib; }
+		autopaste $wm
+		;;
+	    wayland)
+		echo $str | { (( $PRIMESEL )) && wl-copy -p || wl-copy; }
+		autopaste $wm
+		;;
+	    *)
+		echo $str
+		;;
+	esac
+    fi
+}
+
+sig_handler() {
+    trap - SIGINT
+    # echo "[int] $pid"
+    kill -SIGINT $pid
+    send_audio
+    handle_transcription
+    exit
+}
+
 #Hear the complaints of the above tools and do not continue with the sequence:
 set -e
 
-rec -q -t wav $ramf rate 16k silence 1 0.1 1% 1 2.0 5%  2>/dev/null
-
-#The server inference has precedence (i.e. -w will be ignored if -n is present). 
-if [ -n "$IPnPORT" ]; then
-    str=$(curl -S -s $IPnPORT/inference \
-        -H "Content-Type: multipart/form-data" \
-        -F file="@$ramf" \
-        -F temperature="0.0" \
-        -F temperature_inc="0.2" \
-        -F response_format="text")
-# | jq -r '.text' )
-elif [[ "$whf" == *.llamafile ]]; then
-    #echo "Using whisperfile: "
-    str="$($whf -t $NTHR -nt -f $ramf 2>/dev/null)"  
-else
-    str="$(transcribe -t $NTHR -nt -m $WMODEL -f $ramf 2>/dev/null)" 
-fi
-# Whisper detected non-speech events such as (wind blowing): 
-str="${str/\(*\)}"   
-str="${str/\[*\]}"
-str="${str#$'\n'}"    
-str="${str#$'\n'}"
-#Prefer the power of zsh, but lose full POSIX compliance.
-if [ -n "$ZSH_NAME" ]; then
-    str="${str#*([[:space:]])}"
-    str="${(C)str:0:1}${str#?}"
-elif [ -n "$BASH" ]; then
-    #Running in bash because you changed the shebang on line 1
-    str="${str##+([[:space:]])}"
-    str="${str^}"
-else
-    echo "Unknown shell, assuming bash compliance"
-    str="${str##+([[:space:]])}"
-    str="${str^}"
+umask 077
+if (( 1 )); then # previous mode
+    rec -q -t wav "$ramf" rate 16k silence 1 0.1 1% 1 2.0 5% 2>/dev/null
+else # disabled for now
+    # If we want to avoid the 2s sox VAD lag when we stopped to speak
+    # An UI-facing button could kill the process as soon as pressed to retrieve the translation
+    # quickly. Ideally, whisper.cpp server should be used in streaming mode.
+    #
+    # https://github.com/chirlu/sox/pull/4/files is likely desirable to avoid loosing 250ms of audio
+    # Note that in case of interruption, Sox may truncate the wav badly leading whisper.cpp to
+    # believe it's an week-long audio file.
+    rec -q -t wav -r 16k -b 16 -c 1 --buffer 2500  --input-buffer 2500 "$ramf" rate 16k silence 1 0.1 1% 1 2.0 5% &
+    pid=$!
+    trap sig_handler SIGINT
+    wait
 fi
 
-#We have a result, now we make a few decisions:
-#If this is somehow run in a text console: 
-if [[ -z "${DISPLAY}" ]] || [[ -z "${DESKTOP_SESSION}" ]] || [[ -z "${XDG_CURRENT_DESKTOP}" ]]; then
-#"Not running in a known graphics environment. Using standard output:
-    echo $str ; exit 0
-else
-#xsel or wl-copy:
- case "$wm" in
-    "x11")
-        if (( $PRIMESEL )); then
-          echo $str | xsel -ip
-          # Simply clicking the middle mouse button. The user must take care of: 1. Window choice. 2. Position within window.
-          # Thus, autopaste from the primary selection is more unpredictable and requires extra care of window focus and mouse pointer repositioning. 
-          if (( $AUTOPASTE )); then xdotool click 2; fi
-        else
-          echo $str | xsel -ib
-          # The automatic paste option makes more sense when using the CLIPBOARD, not primary sellection.
-          if (( $AUTOPASTE )); then xdotool key ctrl+v; fi
-        fi
-        ;;
-    "wayland")
-        if (( $PRIMESEL )); then
-          echo $str | wl-copy -p
-          # Simply clicking the middle mouse button. The user must take care of: 1. Window choice. 2. Position within window.
-          # Thus, autopaste from the primary selection is more unpredictable and requires extra care of window focus and mouse pointer repositioning. 
-          if (( $AUTOPASTE )); then ydotool click 0xC2; fi
-        else
-          echo $str | wl-copy
-          # The key sym sequence may differ from the one below on a variety of systems and keyboard layouts:
-          if (( $AUTOPASTE )); then ydotool key 37:1 55:1 55:0 37:0 ; fi
-        fi 
-        ;;
-    *)
-        echo $str
-        ;;
- esac
-fi
+send_audio
+handle_transcription

--- a/wsiAI
+++ b/wsiAI
@@ -24,15 +24,12 @@ pidof -q wsiAI && exit 0
 
 #---USER CONFIGURATION BLOCK----------------------------------------------------------------
 #The main configuration for this and all other BlahST tools is now in blahst.cfg, please, edit that file as needed.
-source $HOME/.local/bin/blahst.cfg
+source $HOME/.config/blahst.cfg
+source $HOME/.local/bin/blahst-helpers
 #Local overrides:
 AUTOPASTE=1
 #PRIMESEL=1
 #---END USER CONFIG BLOCK-------------------------------------------------------------------
- 
-#---CHECK DEPENDENCIES.-----Run blahst_depends only if needed or requested----------
-(( $blahst_deps )) || blahst_depends 
-#---END CHECK DEPENDENCIES.-----------------------------------------------------------------
 
 #Hear the complaints of the above tools and do not continue with the sequence:
 set -e
@@ -233,28 +230,12 @@ else
 #echo "Pasting now: "
  case "$wm" in
     "x11")
-        if (( $PRIMESEL )); then
-          echo $str | xsel -ip
-          # Simply clicking the middle mouse button. The user has to take care of: 1. Window choice. 2. Position within window.
-          # Thus, autopaste from the primary selection is more unpredictable and requires extra care of window focus and mouse pointer repositioning. 
-          if (( $AUTOPASTE )); then xdotool click 2 ; fi
-        else
-          echo $str | xsel -ib
-          # The automatic paste option makes more sense when using the CLIPBOARD, not primary sellection.
-          if (( $AUTOPASTE )); then xdotool key ctrl+v ; fi
-        fi
+        echo $str | { (( $PRIMESEL )) && xsel -ip || xsel -ib; }
+	autopaste $wm
         ;;
     "wayland")
-        if (( $PRIMESEL )); then
-          echo $str | wl-copy -p
-          # Simply clicking the middle mouse button. The user has to take care of: 1. Window choice. 2. Position within window.
-          # Thus, autopaste from the primary selection is more unpredictable and requires extra care of window focus and mouse pointer repositioning. 
-          if (( $AUTOPASTE )); then ydotool click 0xC2; fi
-        else
-          echo $str | wl-copy
-          # The key sym sequence may differ from the one below on a variety of systems and keyboard layouts:
-          if (( $AUTOPASTE )); then ydotool key 37:1 55:1 55:0 37:0 ; fi
-        fi 
+	echo $str | { (( $PRIMESEL )) && wl-copy -p || wl-copy; }
+	autopaste $wm
         ;;
     *)
         echo $str

--- a/wsiml
+++ b/wsiml
@@ -1,5 +1,5 @@
 #!/usr/bin/zsh
-# Operation inbash not guranteed.
+# Operation in bash not guranteed.
 # Copyright (c) 2024 Quantius Benignus
 # 
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -21,7 +21,8 @@
 
 #---USER CONFIGURATION BLOCK----------------------------------------------------------------
 #The main configuration for this and all other BlahST tools is now in blahst.cfg, please, edit that file as needed.
-source $HOME/.local/bin/blahst.cfg
+source $HOME/.config/blahst.cfg
+source $HOME/.local/bin/blahst-helpers
 #Local overrides: 
 # Choose a default language for speech input (only those with WER > 50%):
 #lang="auto"
@@ -201,10 +202,6 @@ done
 # Store the remaining arguments in a variable
 rem_args=("$@")
 
-#---CHECK DEPENDENCIES.-----Run blahst_depends only if needed or requested----------
-(( $blahst_deps )) || blahst_depends 
-#---END CHECK DEPENDENCIES.-----------------------------------------------------------------
-
 #Hear the complaints of the above tools and do not continue with the sequence:
 set -e
 
@@ -274,36 +271,20 @@ if [[ -z "${DISPLAY}" ]] || [[ -z "${DESKTOP_SESSION}" ]] || [[ -z "${XDG_CURREN
     #"Not running in a known graphics environment. Using standard output:
     echo $str ; exit 0
 else
- #xsel or wl-copy:
- case "$wm" in
-    "x11")
-        if (( $PRIMESEL )); then
-          echo $str | xsel -ip
-          # Simply clicking the middle mouse button. The user must take care of: 1. Window choice. 2. Position within window.
-          # Thus, autopaste from the primary selection is more unpredictable and requires extra care of window focus and mouse pointer repositioning. 
-          if (( $AUTOPASTE )); then xdotool click 2; fi
-        else
-          echo $str | xsel -ib
-          # The automatic paste option makes more sense when using the CLIPBOARD, not primary sellection.
-          if (( $AUTOPASTE )); then xdotool key ctrl+v; fi
-        fi
-        ;;
-    "wayland")
-        if (( $PRIMESEL )); then
-          echo $str | wl-copy -p
-          # Simply clicking the middle mouse button. The user must take care of: 1. Window choice. 2. Position within window.
-          # Thus, autopaste from the primary selection is more unpredictable and requires extra care of window focus and mouse pointer repositioning. 
-          if (( $AUTOPASTE )); then ydotool click 0xC2; fi
-        else
-          echo $str | wl-copy
-          # The key sym sequence may differ from the one below on a variety of systems and keyboard layouts:
-          if (( $AUTOPASTE )); then ydotool key 37:1 55:1 55:0 37:0 ; fi
-        fi 
-        ;;
-    *)
-        echo $str
-        ;;
- esac
+    #xsel or wl-copy:
+    case "$wm" in
+	"x11")
+	    echo $str | { (( $PRIMESEL )) && xsel -ip || xsel -ib; }
+	    autopaste $wm
+	    ;;
+	"wayland")
+	    echo $str | { (( $PRIMESEL )) && wl-copy -p || wl-copy; }
+	    autopaste $wm
+	    ;;
+	*)
+	    echo $str
+	    ;;
+    esac
 fi
 
 #echo "Text processed and in clipboard now: "$(date +%s.%N)


### PR DESCRIPTION
 - wsi: more functional. Now supports user interruption without having to wait Sox's 2 sec VAD. UI/keybinding could profit from this for a more responsive experience (but it's not true streaming yet)
- wsi: support fixing the language (`LANGUAGE=foo ./wsi`) [but needs UI support] (it's the only non-whitespace change impacting `send_audio()`)
- wsi: back to (chmod 600) `wfile-$USER` to avoid conflicts on multi-seat systems to
    
- config: stripped down logic-free config moved into `~/.config` (user can always create complex script and `source` from .cfg file)
- helpers: extract from the .cfg to be moved into `~/.local/bin/`
- helpers: `autopaste` helper created (+ `xdotool` fallback support for wayland)
    
- install: checking dependencies is a one-off maintenance/install/configuration task better off runtime script to avoid unnecessary complexity to alter readability and maintenance. Created `check_deps` for this purpose (some overlap with `install-wsi`)
- install: `check_deps` improved output and usability (eg: show all errors at once)
    
- cleanups: various simplifications, argument (un)quoting, trailing white-spaces,